### PR TITLE
Fix dependency issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: coherent
+
+MODULES = ipm_furuta
+
+coherent:
+	$(eval VERSION := $(shell grep '^__version__ = ".*"$$' setup.py))
+	@if [ -z '$(VERSION)' ]; then \
+	  echo "Missing version. Check the setup.py file."; \
+	  exit 1; \
+	 fi
+	echo '$(VERSION)'
+
+	sed -i 's|^__version__ = ".*"$$|$(VERSION)|g' $(foreach mod, $(MODULES), $(mod)/__init__.py)

--- a/README.md
+++ b/README.md
@@ -13,5 +13,16 @@ style interface is there mainly for completeness.
 Installing dependencies via the pip package manager:
 
 ```
-pip install scipy matplotlib 
+pip install numpy scipy matplotlib
+```
+
+## Packaging
+
+Make sure to run `make coherent` to ensure that the version from setup.py gets
+propagated to the module.
+
+Build the package using the setup.py script:
+
+```
+python setup.py sdist
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-from ipm_furuta import __version__
+__version__ = "0.0.1"
 
 setup(
     name="ipm_furuta",
@@ -16,6 +16,7 @@ setup(
     ],
     install_requires=[
         "matplotlib",
+        "numpy",
         "scipy"
     ],
     packages=find_packages(


### PR DESCRIPTION
The issue was the it could not run the setup.py script unless dependencies already were installed. This is fixed by statically defining the version in setup.py and using a coherency checker to build the package.